### PR TITLE
Fix some python 2.7 build issues with pyaccumulo

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Visual Studio 2008, Python 3.3 and 3.4 needs Visual Studio 2010, and Python
 
 1. Build the pyaccumulo dependency using the following command (replace Python version number with desired version):
    ```
-   conda build buildscripts/dependency-recipies/pyaccumulo --python 3.5
+   conda build -c gbrener -c defaults -c conda-forge buildscripts/dependency-recipies/pyaccumulo --python 3.5
    ```
 
 1. Build the geodocker-accumulo dependency using the following command (ensure that `docker-compose` is down beforehand):

--- a/buildscripts/dependency-recipies/pyaccumulo/meta.yaml
+++ b/buildscripts/dependency-recipies/pyaccumulo/meta.yaml
@@ -13,9 +13,11 @@ requirements:
   build:
     - python
     - setuptools
-    - thrift
+    - thrift 0.10.0 [py3k]
+    - thrift 0.9.3 [py2k]
     - pytest
     - pytest-cov
+    - pytest-xdist
 
   run:
     - python

--- a/environment.yml
+++ b/environment.yml
@@ -1,13 +1,18 @@
 name: accumuloadapter
+channels:
+  - gbrener
+  - defaults
+  - conda-forge
 dependencies:
-- python
-- ipython
-- numpy
-- pandas
-- pytest
-- cython
-- openssl
-- thrift =0.10.0
-- libthrift =0.10.0
-- boost
-- pytest-cov
+  - python
+  - ipython
+  - numpy
+  - pandas
+  - pytest
+  - cython
+  - openssl
+  - thrift =0.10.0
+  - libthrift =0.10.0
+  - boost
+  - pytest-cov
+  - pytest-xdist


### PR DESCRIPTION
While getting the `pyaccumulo` recipe working for Python 3, the Python 2.7 build for `pyaccumulo` regressed. With some minor tweaks, this commit gets the build working again.